### PR TITLE
updates shared apiserver webhook client

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -12,7 +12,7 @@ This theme uses node-sass/libsass to process the various .scss files. Never edit
 
 * Go to `common/gtk-2.0`
 
-* The colors and includes are defined in `gtkrc`, `gtkrc-dark` and `gtkrc-darker` for each theme variant
+* The colors and includes are defined in `light/gtkrc`, `dark/gtkrc` and `darker/gtkrc` for each theme variant
 
 * `main.rc` contains the major part of the theme
 
@@ -20,20 +20,16 @@ This theme uses node-sass/libsass to process the various .scss files. Never edit
 
 * `apps.rc` contains some application specific rules
 
-Because this theme is heavily based on the pixmap engine, a lot of the styling comes from the images in the `assets` and `assets-dark` folders. Don't edit these images directly. See the next section.
+Because this theme is heavily based on the pixmap engine, a lot of the styling comes from the images in the `light/assets` and `dark/assets` folders. Don't edit these images directly. See the next section.
 
 --
 
 #### Editing the images for the GTK 2 and GTK 3 themes
 
-* Go to the `common/gtk-2.0` or `common/gtk-3.0/$gtk-version` directory
+* Go to the `common/gtk-2.0/light`, `common/gtk-2.0/dark`, or `common/gtk-3.0/$gtk-version` directory.
 
-* Open the `assets.svg` or `assets-dark.svg` file in inkscape. Each object in the .svg file corresponds to an image in the `assets` or `assets-dark` folder
+* Open the `assets.svg` file in inkscape. Each object in the .svg file corresponds to an image in the `assets` folder.
 
 * Find the object you want to edit and make your changes. Important: Don't change the object id!
 
-* Save `assets.svg` and delete the images corresponding to the edited .svg objects from the `assets` folder (or just delete everything in the `assets` folder)
-
-* Run `./render-assets.sh` or `./render-dark-assets.sh` from a terminal
-
-* N.B. If you are making color changes then remove the contents of the folders gtk-2.0/assets/* gtk-2.0/assets-dark and the assets folder under the GTK+3 folder that the theme is compiled for
+* Save `assets.svg` and run `make` (or `make -j$(nproc)` if you're in a hurry) from a terminal in the parent directory.

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ It is strongly encouraged to submit pull-requests to suggest fixes and enhanceme
 To build the theme the following packages are required
 * `autoconf`
 * `automake`
-* `sassc`
+* `sassc` for GTK 3, Cinnamon, or GNOME Shell
 * `pkg-config` or `pkgconfig` for Fedora
 * `git` to clone the source directory
-* `optipng`
-* `inkscape`
+* `optipng` for GTK 2, GTK 3, or XFWM
+* `inkscape` for GTK 2, GTK 3, or XFWM
 
 The following packages are optionally required
 * `gnome-shell`for auto-detecting the GNOME Shell version

--- a/change_color.sh
+++ b/change_color.sh
@@ -19,17 +19,18 @@ is_dark() {
 
 
 print_usage() {
-	echo "usage: $0 [-o OUTPUT_THEME_NAME] [-a AUTOGEN_OPTS] PATH_TO_PRESET"
+	echo "usage: $0 [-o OUTPUT_THEME_NAME] [-a AUTOGEN_OPTS] [-j JOBS] PATH_TO_PRESET"
 	echo
 	echo "examples:"
 	# shellcheck disable=SC2028 # This is meant to be usage text.
 	echo "	$0 --output my-theme-name <(echo -e \"BG=d8d8d8\\nFG=101010\\nMENU_BG=3c3c3c\\nMENU_FG=e6e6e6\\nSEL_BG=ad7fa8\\nSEL_FG=ffffff\\nTXT_BG=ffffff\\nTXT_FG=1a1a1a\\nBTN_BG=f5f5f5\\nBTN_FG=111111\\n\")"
 	echo "	$0 ../colors/retro/twg"
-	echo "	$0 --autogen-opts '--disable-cinnamon --disable-gnome-shell' ../colors/retro/clearlooks"
+	echo "	$0 --autogen-opts '--disable-cinnamon --disable-gnome-shell' --jobs 4 ../colors/retro/clearlooks"
 	exit 1
 }
 
 AUTOGEN_OPTS=""
+unset JOBS
 
 while [[ "$#" -gt 0 ]]; do
 	case "$1" in
@@ -43,6 +44,10 @@ while [[ "$#" -gt 0 ]]; do
 			;;
 		-a|--autogen-opts)
 			AUTOGEN_OPTS="${2}"
+			shift
+			;;
+		-j|--jobs)
+			JOBS="${2}"
 			shift
 		;;
 		*)
@@ -223,8 +228,8 @@ for template_file in $(find ./common -name '*.thpl') ; do
 done
 
 ASSETS_FILES=(
-	'./common/gtk-2.0/assets.svg'
-	'./common/gtk-2.0/assets-dark.svg'
+	'./common/gtk-2.0/light/assets.svg'
+	'./common/gtk-2.0/dark/assets.svg'
 	'./common/gtk-3.0/3.18/assets.svg'
 	'./common/gtk-3.0/3.20/assets.svg'
 )
@@ -292,7 +297,7 @@ fi
 echo "== Making theme..."
 mkdir distrib
 ./autogen.sh --prefix=$(readlink -e ./distrib/) --disable-light --disable-dark ${AUTOGEN_OPTS}
-make install
+make --jobs="${JOBS:-$(nproc || echo 1)}" install
 echo
 
 echo

--- a/common/gtk-3.0/3.20/Makefile.am
+++ b/common/gtk-3.0/3.20/Makefile.am
@@ -16,8 +16,11 @@ dark/gtk-main-dark.css: | dark
 %/gtk.css %/gtk-dark.css: | %
 	echo '@import url("resource:///org/gnome/arc-theme/$(subst gtk,gtk-main,$(notdir $@))");' > "$@"
 
-%/gtk.gresource.xml: | %
-	echo "<?xml version='1.0' encoding='UTF-8'?><gresources><gresource prefix='/org/gnome/arc-theme'>$(patsubst %,<file preprocess='to-pixdata'>../%</file>,$(normal) $(hidpi))<file>gtk-main.css</file>$(if $(filter $(dir $@),dark/),,<file>gtk-main-dark.css</file>)</gresource></gresources>" > "$@"
+%/assets: | %
+	(cd "$(dir $@)" && $(LN_S) ../assets assets)
+
+%/gtk.gresource.xml: | %/assets
+	echo "<?xml version='1.0' encoding='UTF-8'?><gresources><gresource prefix='/org/gnome/arc-theme'>$(patsubst %,<file preprocess='to-pixdata'>%</file>,$(normal) $(hidpi))<file>gtk-main.css</file>$(if $(filter $(dir $@),dark/),,<file>gtk-main-dark.css</file>)</gresource></gresources>" > "$@"
 
 %/gtk.gresource: %/gtk.gresource.xml %/gtk-main.css %/gtk-main-dark.css $(normal) $(hidpi)
 	glib-compile-resources --sourcedir="$(dir $<)" --target="$@" "$<"

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_INIT(
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([no-dist-gzip dist-xz foreign])
+AC_PROG_LN_S
 AC_PROG_MKDIR_P
 
 ARC_ENABLE([LIGHT],         [light],         [Arc Light],     [disable])


### PR DESCRIPTION
* Fix image path names in GTK+3 gresource files

Turns out it cares about the whole path, not just the filename, even
if you embed the pixdata.

* Fix change_color.sh following autotools changes

* Add --jobs option to change_color.sh to pass to make

This defaults to nproc.

* Update HACKING document following autotools changes

* Note in README which engines require sassc, optipng, and inkscape