### PR TITLE
generateExpression (no trailing semicolon) 

### DIFF
--- a/common/gtk-3.0/3.20/sass/_common.scss
+++ b/common/gtk-3.0/3.20/sass/_common.scss
@@ -2334,12 +2334,12 @@ progressbar {
 //
 levelbar {
   block {
-    min-width: 32px;
-    min-height: 1px;
+    min-width: 1px;
+    min-height: 20px;
   }
   &.vertical block {
-    min-width: 1px;
-    min-height: 32px;
+    min-width: 32px;
+    min-height: 1px;
   }
 
   trough {


### PR DESCRIPTION
* Fix vertical and horizontal levelbar values

The horizontal levelbar auto-width and auto-height values were used wrongly for vertical levelbar and vis versa.

* 20px min-height on horizontal bars looks better